### PR TITLE
PetStatus enum

### DIFF
--- a/src/main/java/com/memopet/memopet/domain/pet/entity/Pet.java
+++ b/src/main/java/com/memopet/memopet/domain/pet/entity/Pet.java
@@ -60,6 +60,10 @@ public class Pet extends FirstCreatedEntity {
     @Column(nullable = false)
     private Gender gender;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PetStatus petStatus;
+
     @Column(name = "deleted_date")
     private LocalDateTime deletedDate;
 

--- a/src/main/java/com/memopet/memopet/domain/pet/entity/PetStatus.java
+++ b/src/main/java/com/memopet/memopet/domain/pet/entity/PetStatus.java
@@ -1,0 +1,6 @@
+package com.memopet.memopet.domain.pet.entity;
+
+public enum PetStatus {
+    ACTIVE, DEACTIVE
+
+}

--- a/src/test/java/com/memopet/memopet/pet/MemoryTest.java
+++ b/src/test/java/com/memopet/memopet/pet/MemoryTest.java
@@ -65,6 +65,7 @@ public class MemoryTest {
 
         Pet pet = Pet.builder()
                 .member(member)
+                .petStatus(PetStatus.ACTIVE)
                 .petName("몬뭉이")
                 .gender(Gender.F)
                 .species(species)
@@ -146,6 +147,7 @@ public class MemoryTest {
         //pet에 species 포함시키기.
         Pet pet = Pet.builder()
                 .member(member)
+                .petStatus(PetStatus.ACTIVE)
                 .petName("몬뭉이")
                 .gender(Gender.F)
                 .species(species)
@@ -208,6 +210,7 @@ public class MemoryTest {
         Species findSpecies = speciesRepository.save(species);
         Pet pet = Pet.builder()
                 .member(findmember)
+                .petStatus(PetStatus.ACTIVE)
                 .petName("몬뭉이")
                 .gender(Gender.F)
                 .species(findSpecies)
@@ -247,6 +250,7 @@ public class MemoryTest {
         Species findSpecies1 = speciesRepository.save(species1);
         Pet pet1 = Pet.builder()
                 .member(findmember1)
+                .petStatus(PetStatus.ACTIVE)
                 .petName("애옹이")
                 .gender(Gender.F)
                 .species(species1)

--- a/src/test/java/com/memopet/memopet/pet/PetTest.java
+++ b/src/test/java/com/memopet/memopet/pet/PetTest.java
@@ -117,6 +117,7 @@ public class PetTest {
         Species savedSpecies = speciesRepository.save(species);
         Pet pet = Pet.builder()
                 .species(savedSpecies)
+                .petStatus(PetStatus.ACTIVE)
                 .member(findMember)
                 .petName("방울이")
                 .petBirth(LocalDate.now())
@@ -178,6 +179,7 @@ public class PetTest {
         Pet pet = Pet.builder()
                 .species(savedSpecies)
                 .member(findMember)
+                .petStatus(PetStatus.ACTIVE)
                 .petName("방울이")
                 .petBirth(LocalDate.now())
                 .petProfileUrl("https://images.unsplash.com/photo-1528301721190-186c3bd85418?q=80&w=1000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxleHBsb3JlLWZlZWR8Mnx8fGVufDB8fHx8fA%3D%3D")
@@ -227,6 +229,7 @@ public class PetTest {
         Species savedSpecies = speciesRepository.save(species);
         Pet pet = Pet.builder()
                 .species(savedSpecies)
+                .petStatus(PetStatus.ACTIVE)
                 .member(findMember)
                 .petName("방울이")
                 .petBirth(LocalDate.now())


### PR DESCRIPTION
Feat: PetStatus enum

유저의 펫중에 ACTIVE한것과 DEACTIVE한것들 구분용.
pet에도 petStatus 이넘 추가, petTest, memoryTest에 pet 초기화 부분에도 추가했음.